### PR TITLE
unit test coverage report archival

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -48,6 +48,10 @@ withPipeline(type, product, component) {
     yarnBuilder.yarn('build')
   }
 
+  after('test') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'coverage/**/*'
+  }
+
   before('functionalTest:preview') {
     env.ADOP_WEB_URL = "https://adoption-web-pr-${CHANGE_ID}.service.core-compute-preview.internal/"
     env.TEST_RETRIES = 5

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -56,6 +56,10 @@ withNightlyPipeline(type, product, component) {
   enableFullFunctionalTest(120)
   loadVaultSecrets(secrets)
 
+  after('test') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'coverage/**/*'
+  }
+
   before('crossBrowserTest') {
     env.TEST_RETRIES = 5
   }


### PR DESCRIPTION
### Change description
Implemented after(test) hook in `Jenkinsfile_CNP` to archive unit test coverage report 

### JIRA link

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
