### PR TITLE
'Go to homepage' link removed from cookies page.

### DIFF
--- a/src/main/steps/application/cookies/template.njk
+++ b/src/main/steps/application/cookies/template.njk
@@ -12,7 +12,8 @@
       <div>
         <p class="govuk-body-m">{{ additionalCookies }}</p>
       </div>
-      <a class="govuk-link" href="/">{{ goToHomepage }}</a>
+      {# Below link has been commented as same cookie page is being used for LA portal and CUI hence we don't have dedicated home page for both the applications. #}
+      {# <a class="govuk-link" href="/">{{ goToHomepage }}</a> #}
     </div>
   </div>
   <section>


### PR DESCRIPTION
### Change description
Homepage link removed from the cookies confirmation.

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-1016

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
