### PR TITLE
SNI-4911-excluded laDocumentsUploaded from redis

### DIFF
--- a/src/main/modules/draft-store/draft-store-service.ts
+++ b/src/main/modules/draft-store/draft-store-service.ts
@@ -25,6 +25,7 @@ export const saveDraftCase = async (req: AppRequest, caseRef: string, formData: 
     'selectedSiblingOtherPlacementOrderType',
     'selectedSiblingPoType',
     'selectedSiblingRelation',
+    'laDocumentsUploaded',
   ];
   const expireTimeInSec: number = config.get('services.draftStore.redis.ttl');
   fieldsToBeExcluded.forEach(item => {


### PR DESCRIPTION
### Change description
LA portal user unable to submit application, on the statement of truth screen - error message is 'There is a problem - sorry we are unable to save your application right now. Please try again later'.

It has been observed that when LA tries to upload and delete the documents , this error occurs.  

### JIRA link
https://tools.hmcts.net/jira/browse/SNI-4911

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x ] No
