### PR TITLE
Added the fix for incident

### DIFF
--- a/charts/adoption-web/values.preview.template.yaml
+++ b/charts/adoption-web/values.preview.template.yaml
@@ -14,9 +14,9 @@ nodejs:
     APPINSIGHTS_KEY: '00000000-0000-0000-0000-000000000000'
     PCQ_ENABLED: 'true'
     REDIS_TTL_MS: 30
-    CCD_URL: 'http://ccd-data-store-api-aat.service.core-compute-aat.internal'
+    CCD_URL: 'http://adoption-cos-api-pr-890-ccd-data-store-api'
     IDAM_ROLE: 'citizen'
-    CDAM_API_URL: 'http://ccd-case-document-am-api-aat.service.core-compute-aat.internal'
+    CDAM_API_URL: 'http://adoption-cos-api-pr-890-ccd-case-document-am-api'
     # Family Court List
     LEICESTER_VAL: 'Leicester County Court'
     STOKE-ON-TRENT_VAL: 'Stoke-on-Trent Combined Court'

--- a/src/main/steps/children/find-family-court/util.ts
+++ b/src/main/steps/children/find-family-court/util.ts
@@ -72,7 +72,6 @@ export const getCourtEmailId = (key: string): string => {
     ['wrexham', config.get('localCourt.emailId.WREXHAM_FAMILY_COURT')],
   ]);
   //Creating array of arrays from map. Then filtering key from map based on input string.
-  //const filteredElement = Array.from(map).filter(([mapKey]) => courtKey.includes(mapKey));
   const filteredElement = Array.from(map).filter(([mapKey]) => courtKey.startsWith(mapKey));
 
   //filtered element will contain a single array item something like  [['liverpool','adoptionsliverpoolcivilandfamilycourt@justice.gov.uk' ]].

--- a/src/main/steps/children/find-family-court/util.ts
+++ b/src/main/steps/children/find-family-court/util.ts
@@ -12,7 +12,6 @@ export const getCourtEmailId = (key: string): string => {
     ['worcester', config.get('localCourt.emailId.WORCESTER_FAMILY_COURT')],
     ['newport', config.get('localCourt.emailId.NEWPORT_GWENT_FAMILY_COURT')],
     ['liverpool', config.get('localCourt.emailId.LIVERPOOL_FAMILY_COURT')],
-    ['central london', config.get('localCourt.emailId.CENTRAL_LONDON_FAMILY_COURT')],
     ['reading', config.get('localCourt.emailId.READING_FAMILY_COURT')],
     //Midlands
     ['stoke-on-trent', config.get('localCourt.emailId.STOKE-ON-TRENT_FAMILY_COURT')],
@@ -67,13 +66,14 @@ export const getCourtEmailId = (key: string): string => {
     ['haverfordwest', config.get('localCourt.emailId.HAVERFORDWEST_FAMILY_COURT')],
     ['llanelli', config.get('localCourt.emailId.LLANELLI_FAMILY_COURT')],
     ['pontypridd', config.get('localCourt.emailId.PONTYPRIDD_FAMILY_COURT')],
-    ['port-talbot', config.get('localCourt.emailId.PORT_TALBOT_FAMILY_COURT')],
+    ['port talbot', config.get('localCourt.emailId.PORT_TALBOT_FAMILY_COURT')],
     ['prestatyn', config.get('localCourt.emailId.PRESTATYN_FAMILY_COURT')],
     ['swansea', config.get('localCourt.emailId.SWANSEA_FAMILY_COURT')],
     ['wrexham', config.get('localCourt.emailId.WREXHAM_FAMILY_COURT')],
   ]);
   //Creating array of arrays from map. Then filtering key from map based on input string.
-  const filteredElement = Array.from(map).filter(([mapKey]) => courtKey.includes(mapKey));
+  //const filteredElement = Array.from(map).filter(([mapKey]) => courtKey.includes(mapKey));
+  const filteredElement = Array.from(map).filter(([mapKey]) => courtKey.startsWith(mapKey));
 
   //filtered element will contain a single array item something like  [['liverpool','adoptionsliverpoolcivilandfamilycourt@justice.gov.uk' ]].
   //Using index to get the email element.


### PR DESCRIPTION
### Change description

There was a bug in the source code wherin , when "Manchester" keyword from type ahead text box in the court was exxtracting the email of Chester court.  This can be replicated in AAT by selecting the family court in CUI as Manchester court and the application will go to Chester email Id.

### JIRA link
https://tools.hmcts.net/jira/browse/SNI-4983

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x ] No
