### PR TITLE
[ADOP-2323] temporarily removed ITHC from branchesToSync

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -41,7 +41,7 @@ def secrets = [
 ]
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
-def branchesToSync = ['demo', 'ithc', 'perftest']
+def branchesToSync = ['demo', 'perftest']
 
 def pipelineConf = new AppPipelineConfig()
 pipelineConf.vaultSecrets = secrets


### PR DESCRIPTION
### Change description
Removed ithc from branchesToSync in Jenkinsfile_CNP so that it can be used as the test environment.

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-2323
To be reverted as part of: https://tools.hmcts.net/jira/browse/ADOP-2425


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
