### PR TITLE
[ADOP-2425] adding ITHC back into branchesToSync

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -41,7 +41,7 @@ def secrets = [
 ]
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
-def branchesToSync = ['demo', 'perftest']
+def branchesToSync = ['demo', 'ithc', 'perftest']
 
 def pipelineConf = new AppPipelineConfig()
 pipelineConf.vaultSecrets = secrets


### PR DESCRIPTION
### Change description
ITHC no longer required for testing ADOP-2323 PR.

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-2425

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
