### PR TITLE
[ADOP-2408] remove redundant HPA config from charts (moved to cnp-flux)

### DIFF
--- a/charts/adoption-web/Chart.yaml
+++ b/charts/adoption-web/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for adoption-web App
 name: adoption-web
 home: https://github.com/hmcts/adoption-web
-version: 0.0.60
+version: 0.0.61
 dependencies:
   - name: nodejs
     version: 3.1.0

--- a/charts/adoption-web/values.aat.template.yaml
+++ b/charts/adoption-web/values.aat.template.yaml
@@ -2,9 +2,5 @@ nodejs:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-  devmemoryLimits: 2Gi
-  devmemoryRequests: 512Mi
-  devcpuLimits: 1000m
-  devcpuRequests: 500m
 idam-pr:
   enabled: false

--- a/charts/adoption-web/values.preview.template.yaml
+++ b/charts/adoption-web/values.preview.template.yaml
@@ -4,6 +4,8 @@ nodejs:
   ingressHost: ${SERVICE_FQDN}
   ingressIP: ${INGRESS_IP}
   consulIP: ${CONSUL_LB_IP}
+  autoscaling:
+    enabled: false
   environment:
     APPINSIGHTS_KEY: '00000000-0000-0000-0000-000000000000'
     PCQ_ENABLED: 'true'

--- a/charts/adoption-web/values.preview.template.yaml
+++ b/charts/adoption-web/values.preview.template.yaml
@@ -4,6 +4,10 @@ nodejs:
   ingressHost: ${SERVICE_FQDN}
   ingressIP: ${INGRESS_IP}
   consulIP: ${CONSUL_LB_IP}
+  devmemoryLimits: 1536Mi
+  devmemoryRequests: 512Mi
+  devcpuLimits: 500m
+  devcpuRequests: 50m
   autoscaling:
     enabled: false
   environment:

--- a/charts/adoption-web/values.preview.template.yaml
+++ b/charts/adoption-web/values.preview.template.yaml
@@ -4,12 +4,6 @@ nodejs:
   ingressHost: ${SERVICE_FQDN}
   ingressIP: ${INGRESS_IP}
   consulIP: ${CONSUL_LB_IP}
-  devmemoryLimits: 2Gi
-  devmemoryRequests: 512Mi
-  devcpuLimits: 1000m
-  devcpuRequests: 500m
-  autoscaling:
-    enabled: false
   environment:
     APPINSIGHTS_KEY: '00000000-0000-0000-0000-000000000000'
     PCQ_ENABLED: 'true'

--- a/charts/adoption-web/values.yaml
+++ b/charts/adoption-web/values.yaml
@@ -3,10 +3,6 @@ nodejs:
   applicationPort: 3000
   readinessDelay: 130
   livenessDelay: 130
-  autoscaling: # Default is false
-    enabled: true
-    maxReplicas: 5 # Required setting
-    targetCPUUtilizationPercentage: 80 # Default is 80% target CPU utilization
   aadIdentityName: adoption
   ingressHost: adoption-web.{{ .Values.global.environment }}.platform.hmcts.net
 

--- a/charts/adoption-web/values.yaml
+++ b/charts/adoption-web/values.yaml
@@ -1,7 +1,6 @@
 nodejs:
   image: 'hmctspublic.azurecr.io/adoption/web:latest'
   applicationPort: 3000
-  readinessDelay: 130
   livenessDelay: 130
   aadIdentityName: adoption
   ingressHost: adoption-web.{{ .Values.global.environment }}.platform.hmcts.net

--- a/charts/adoption-web/values.yaml
+++ b/charts/adoption-web/values.yaml
@@ -1,7 +1,6 @@
 nodejs:
   image: 'hmctspublic.azurecr.io/adoption/web:latest'
   applicationPort: 3000
-  livenessDelay: 130
   aadIdentityName: adoption
   ingressHost: adoption-web.{{ .Values.global.environment }}.platform.hmcts.net
 


### PR DESCRIPTION
### Change description
Moving AAT pod config to cnp-flux

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-2408

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
