### PR TITLE
ADOP-2536: Welsh wording change on content.ts

### DIFF
--- a/src/main/steps/la-portal/check-your-answers/content.test.ts
+++ b/src/main/steps/la-portal/check-your-answers/content.test.ts
@@ -291,12 +291,14 @@ describe('check-your-answer > content', () => {
     );
   });
 
+  // Tech Debt, see ADOP-2580
   test('should contain submit button', () => {
     const generatedContent = generateContent(commonContent);
     const form = generatedContent.form as FormContent;
     expect((form.submit.text as Function)(generatePageContent({ language: 'en' }))).toBe('Save and continue');
   });
 
+  // Tech Debt, see ADOP-2580
   test('should contain welsh submit button in welsh content', () => {
     const generatedContent = generateContent(commonContent);
     const form = generatedContent.form as FormContent;

--- a/src/main/steps/la-portal/check-your-answers/content.test.ts
+++ b/src/main/steps/la-portal/check-your-answers/content.test.ts
@@ -10,8 +10,7 @@ import {
   SiblingRelationships,
   YesNoNotsure,
 } from '../../../app/case/definition';
-import { FormContent } from '../../../app/form/Form';
-import { CommonContent, generatePageContent } from '../../common/common.content';
+import { CommonContent } from '../../common/common.content';
 
 import { generateContent } from './content';
 
@@ -289,20 +288,6 @@ describe('check-your-answer > content', () => {
         language: 'cy',
       })
     );
-  });
-
-  // Tech Debt, see ADOP-2580
-  test('should contain submit button', () => {
-    const generatedContent = generateContent(commonContent);
-    const form = generatedContent.form as FormContent;
-    expect((form.submit.text as Function)(generatePageContent({ language: 'en' }))).toBe('Save and continue');
-  });
-
-  // Tech Debt, see ADOP-2580
-  test('should contain welsh submit button in welsh content', () => {
-    const generatedContent = generateContent(commonContent);
-    const form = generatedContent.form as FormContent;
-    expect((form.submit.text as Function)(generatePageContent({ language: 'cy' }))).toBe('Cadw a pharhau');
   });
 });
 /* eslint-enable @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any */

--- a/src/main/steps/la-portal/check-your-answers/content.test.ts
+++ b/src/main/steps/la-portal/check-your-answers/content.test.ts
@@ -19,6 +19,7 @@ const enContent = {
   title: 'Check your answers',
   change: 'Change',
   reason: 'Reason',
+  continue: 'Continue',
   submitApplication: 'Check your answers',
   checkInfoBeforeSubmit1:
     'Check all the information you have provided. If you need to edit any of the answers, select the change link at the end of the relevant answer.',
@@ -145,6 +146,7 @@ const cyContent: typeof enContent = {
   title: 'Adolygu eich atebion',
   change: 'Newid',
   reason: 'Rheswm',
+  continue: 'Parhau',
   submitApplication: 'Gwirio eich cais',
   checkInfoBeforeSubmit1:
     'Gwiriwch yr holl wybodaeth yr ydych wedi’i rhoi yn ofalus. Y cam nesaf yw arwyddo’r datganiad gwirionedd i ddatgan bod yr wybodaeth a roddwyd yn gywir. Unwaith y bydd wedi’i arwyddo a’r taliad wedi’i wneud, bydd eich cais yn cael ei gyflwyno i’r llys.',
@@ -295,10 +297,10 @@ describe('check-your-answer > content', () => {
     expect((form.submit.text as Function)(generatePageContent({ language: 'en' }))).toBe('Save and continue');
   });
 
-  /* test('should contain save-as-draft button', () => {
+  test('should contain welsh submit button in welsh content', () => {
     const generatedContent = generateContent(commonContent);
     const form = generatedContent.form as FormContent;
-    expect((form.saveAsDraft!.text as Function)(generatePageContent({ language: 'en' }))).toBe('Save as draft');
-  }); */
+    expect((form.submit.text as Function)(generatePageContent({ language: 'cy' }))).toBe('Cadw a pharhau');
+  });
 });
 /* eslint-enable @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any */

--- a/src/main/steps/la-portal/check-your-answers/content.ts
+++ b/src/main/steps/la-portal/check-your-answers/content.ts
@@ -186,7 +186,7 @@ const cyContent: typeof enContent = {
     'Gwiriwch yr holl wybodaeth yr ydych wedi’i rhoi yn ofalus. Y cam nesaf yw arwyddo’r datganiad gwirionedd i ddatgan bod yr wybodaeth a roddwyd yn gywir. Unwaith y bydd wedi’i arwyddo a’r taliad wedi’i wneud, bydd eich cais yn cael ei gyflwyno i’r llys.',
   checkInfoBeforeSubmit2:
     'Gwiriwch yr holl wybodaeth yr ydych wedi’i rhoi yn ofalus. Y cam nesaf yw arwyddo’r datganiad gwirionedd i ddatgan bod yr wybodaeth a roddwyd yn gywir. Unwaith y bydd wedi’i arwyddo a’r taliad wedi’i wneud, bydd eich cais yn cael ei gyflwyno i’r llys.',
-  continue: 'Continue',
+  continue: 'Parhau',
   applyingWith: {
     [ApplyingWith.ALONE]: 'Rwy’n gwneud cais ar fy mhen fy hun',
     [ApplyingWith.WITH_SPOUSE_OR_CIVIL_PARTNER]: 'Rwy’n gwneud cais gyda fy mhriod neu fy mhartner sifil',


### PR DESCRIPTION
**Before creating a pull request make sure that:**

### Change description
Wording change to la-portal/check-your-answers "Continue" button. Welsh continue button had incorrect English spelling. It is now Parhau.

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-2356

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x ] No
