### PR TITLE
[ADOP-2408] adding dev memory and cpu values back into AAT chart

### DIFF
--- a/charts/adoption-web/values.aat.template.yaml
+++ b/charts/adoption-web/values.aat.template.yaml
@@ -2,5 +2,9 @@ nodejs:
   # Don't modify below here
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+  devmemoryLimits: 1536Mi
+  devmemoryRequests: 512Mi
+  devcpuLimits: 500m
+  devcpuRequests: 50m
 idam-pr:
   enabled: false


### PR DESCRIPTION
### Change description
https://github.com/hmcts/adoption-web/pull/1595 caused issues with AAT pods ("NODE_ENV value of 'production' did not match any deployment config file names.") so this is a partial revert.

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-2408

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
