### PR TITLE
[ADOP-2579] Move Dynatrace RUM to page head

### DIFF
--- a/src/main/steps/common/cookie-banner.njk
+++ b/src/main/steps/common/cookie-banner.njk
@@ -1,17 +1,5 @@
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
-<p hidden>Current env: {{currentEnv}} </p>
-
-{% block head %}
-
-  {% if ['aat'].includes(currentEnv) %}
-    <script type="text/javascript" src="https://js-cdn.dynatrace.com/jstag/17177a07246/bf24054dsx/fb3a85222a00a995_complete.js" crossorigin="anonymous"></script>
-  {% elif ['prod'].includes(currentEnv) %}
-    <script type="text/javascript" src="https://js-cdn.dynatrace.com/jstag/17177a07246/bf00910jpo/5f55faf7cef058ac_complete.js" crossorigin="anonymous"></script>
-  {% endif %}
-
-{% endblock %}
-
 {% set html %}
   <input type="hidden" name="cookie_locale" id="cookie_locale" value="{{ language }}">
   <p class="govuk-body">{{cookiesLine1}}</p>

--- a/src/main/steps/common/page.njk
+++ b/src/main/steps/common/page.njk
@@ -22,6 +22,15 @@
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-K66QQ98');</script>
   <!-- End Google Tag Manager -->
+
+  <!-- Dynatrace RUM -->
+  {% if ['aat'].includes(currentEnv) %}
+    <script type="text/javascript" src="https://js-cdn.dynatrace.com/jstag/17177a07246/bf24054dsx/fb3a85222a00a995_complete.js" crossorigin="anonymous"></script>
+  {% elif ['prod'].includes(currentEnv) %}
+    <script type="text/javascript" src="https://js-cdn.dynatrace.com/jstag/17177a07246/bf00910jpo/5f55faf7cef058ac_complete.js" crossorigin="anonymous"></script>
+  {% endif %}
+  <!-- End Dynatrace RUM -->
+
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
### Change description
Move dyntrace tracking scripts into the head, not cookie-banner

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-2579

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
