### PR TITLE
[ADOP-2575] update terraform azurerm to 4.0.0

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.116.0"
+      version = "4.0.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
### Change description
Update terraform azurerm to a minimum of 4.0.0

### JIRA link
https://tools.hmcts.net/jira/browse/ADOP-2575

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
