### PR TITLE
Remove dependabot as we have renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10


### PR DESCRIPTION
### Change description
- Removing dependabot as per recommendations on https://hmcts.github.io/cloud-native-platform/guides/automated-dependency-updates.html#dependabot-vs-renovate

### JIRA link
N/A
**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
