### PR TITLE
ADOP-2628: Update nodejs chart to 3.2.0 and use OCI repo

### DIFF
--- a/charts/adoption-web/Chart.yaml
+++ b/charts/adoption-web/Chart.yaml
@@ -3,11 +3,11 @@ appVersion: '1.0'
 description: A Helm chart for adoption-web App
 name: adoption-web
 home: https://github.com/hmcts/adoption-web
-version: 0.0.61
+version: 0.0.62
 dependencies:
   - name: nodejs
-    version: 3.1.0
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: 3.2.0
+    repository: 'oci://hmctspublic.azurecr.io/helm'
   - name: idam-pr
     version: 2.2.7
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION
### Change description

Update nodejs chart to 3.2.0 and use OCI repo

### JIRA link

https://tools.hmcts.net/jira/browse/ADOP-2628

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No