### PR TITLE
ADOP-2647: PCQ env variable added

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -93,6 +93,7 @@ withPipeline(type, product, component) {
 
   before('smoketest:aat') {
     env.ADOP_WEB_URL = "https://adoption-web-staging.aat.platform.hmcts.net/"
+    env.PCQ_TESTS_ENABLED = false
   }
 
   afterAlways('smoketest:aat') {

--- a/playwright-e2e/tests/smoke.spec.ts
+++ b/playwright-e2e/tests/smoke.spec.ts
@@ -5,6 +5,7 @@ import * as dotenv from 'dotenv';
 import { runAccessibilityScan } from '../helpers/accessibilityHelper';
 import { setupUser, teardownUser } from '../hooks/createDeleteUser.hook';
 import App from '../pages/app.page';
+import { toggleConfig } from '../utils/toggles';
 
 dotenv.config();
 
@@ -73,7 +74,9 @@ test.describe('smoke test', () => {
 
     // Submit
     await app.tasklist.reviewAndSubmit.click();
-    await app.pcq.noPcqAnswers();
+    if (toggleConfig.pcqTestsEnabled) {
+      await app.pcq.noPcqAnswers();
+    }
     await app.reviewSubmit.reviewAnswers(applicantNumber);
     await app.basePage.clickSaveAndContinue();
     await app.reviewSubmit.statementOfTruthOne(appOneName.appOneFullname);

--- a/playwright-e2e/utils/toggles.ts
+++ b/playwright-e2e/utils/toggles.ts
@@ -1,0 +1,11 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+interface ToggleConfig {
+  [key: string]: string | boolean;
+}
+
+export const toggleConfig: ToggleConfig = {
+  pcqTestsEnabled: process.env.PCQ_TESTS_ENABLED || true,
+};


### PR DESCRIPTION
pcq is disabled in master pipeline checks, pcq env variables used for filtering functionality in tests.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ x] No
