### PR TITLE
ADOP-2670-2: Add All classifier and revert version to 1.4.8

### DIFF
--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9'
+    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.8', classifier: 'all'
     testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.4'
 }
 //end::dependencies[]


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ADOP-2670

Add All classifier and reduce version to align with FPL

Contains all current published deps: https://dev.azure.com/hmcts/Artifacts/_artifacts/feed/hmcts-lib

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
