### PR TITLE
ADOP-2670-2: Update JVM to use Java 17 and Fortify use artifacts version

### DIFF
--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9'
+    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.8', classifier: 'all'
     testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.4'
 }
 //end::dependencies[]

--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'application'
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.17
+targetCompatibility = 1.17
 
 // tag::repositories[]
 repositories {
@@ -18,7 +18,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.8', classifier: 'all'
+    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9', classifier: 'all'
     testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.4'
 }
 //end::dependencies[]


### PR DESCRIPTION
Use updated fortify client and update Java client to use java 17

https://dev.azure.com/hmcts/Artifacts/_artifacts/feed/hmcts-lib/maven/com.github.hmcts%2Ffortify-client/versions/1.4.9

https://tools.hmcts.net/jira/browse/ADOP-2670

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No
